### PR TITLE
:sparkles: - Add consumer integration tests for reusable workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,13 +6,26 @@ on:
       workspace:
         type: string
         required: true
+      target-repository:
+        description: "Repository to checkout for running checks (default: caller repository)"
+        type: string
+        required: false
+        default: ""
+      target-ref:
+        description: "Ref of target-repository to checkout (default: caller ref)"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
   read-toolchain:
-    uses: ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main
+    uses: ./.github/workflows/read-toolchain.yml
+    with:
+      target-repository: ${{ inputs.target-repository }}
+      target-ref: ${{ inputs.target-ref }}
 
   check:
     needs: [read-toolchain]
@@ -24,6 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ inputs.target-repository }}
+          ref: ${{ inputs.target-ref }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
@@ -36,11 +51,10 @@ jobs:
         run: cargo fmt --verbose -p $WORKSPACE -- --check
         env:
           WORKSPACE: ${{ matrix.workspace }}
-      - uses: giraffate/clippy-action@13b9d32482f25d29ead141b79e7e04e7900281e0 # v1.0.1
-        with:
-          reporter: 'github-pr-review'
-          clippy_flags: '-p ${{ matrix.workspace }} -- -Dwarnings'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clippy
+        run: cargo clippy --verbose -p "$WORKSPACE" --all-targets -- -D warnings
+        env:
+          WORKSPACE: ${{ matrix.workspace }}
       - name: Build
         run: cargo build --verbose -p $WORKSPACE
         env:

--- a/.github/workflows/detect-workspaces.yml
+++ b/.github/workflows/detect-workspaces.yml
@@ -2,6 +2,17 @@ name: DetectWorkspaces
 
 on:
   workflow_call:
+    inputs:
+      target-repository:
+        description: "Repository to checkout for detection (default: caller repository)"
+        type: string
+        required: false
+        default: ""
+      target-ref:
+        description: "Ref of target-repository to checkout (default: caller ref)"
+        type: string
+        required: false
+        default: ""
     outputs:
       matrix:
         description: "Detected workspaces for using matrix"
@@ -17,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ inputs.target-repository }}
+          ref: ${{ inputs.target-ref }}
           persist-credentials: false
       - uses: baptiste0928/cargo-install@b687c656bda5733207e629b50a22bf68974a0305 # v3.3.2
         with:
@@ -29,4 +42,3 @@ jobs:
           echo "matrix=$WORKSPACES" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    

--- a/.github/workflows/read-toolchain.yml
+++ b/.github/workflows/read-toolchain.yml
@@ -2,6 +2,17 @@ name: Read rust-toolchain.toml
 
 on:
   workflow_call:
+    inputs:
+      target-repository:
+        description: "Repository to checkout for reading toolchain (default: caller repository)"
+        type: string
+        required: false
+        default: ""
+      target-ref:
+        description: "Ref of target-repository to checkout (default: caller ref)"
+        type: string
+        required: false
+        default: ""
     outputs:
       channel:
         description: "Detected toolchain channel"
@@ -17,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ inputs.target-repository }}
+          ref: ${{ inputs.target-ref }}
           persist-credentials: false
       - uses: SebRollen/toml-action@b1b3628f55fc3a28208d4203ada8b737e9687876 # v1.2.0
         id: toolchain

--- a/.github/workflows/test-consumers.yml
+++ b/.github/workflows/test-consumers.yml
@@ -16,21 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  stellar-detect:
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-    uses: ./.github/workflows/detect-workspaces.yml
-    with:
-      target-repository: ShuttlePub/Stellar
-      target-ref: main
-
-  stellar-check:
-    needs: [stellar-detect]
-    uses: ./.github/workflows/check.yml
-    with:
-      workspace: ${{ needs.stellar-detect.outputs.matrix }}
-      target-repository: ShuttlePub/Stellar
-      target-ref: main
-
   emumet-check:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/check.yml

--- a/.github/workflows/test-consumers.yml
+++ b/.github/workflows/test-consumers.yml
@@ -1,0 +1,48 @@
+name: Test consumers
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  stellar-detect:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/detect-workspaces.yml
+    with:
+      target-repository: ShuttlePub/Stellar
+      target-ref: main
+
+  stellar-check:
+    needs: [stellar-detect]
+    uses: ./.github/workflows/check.yml
+    with:
+      workspace: ${{ needs.stellar-detect.outputs.matrix }}
+      target-repository: ShuttlePub/Stellar
+      target-ref: main
+
+  emumet-check:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/check.yml
+    with:
+      workspace: '[ "kernel", "adapter", "application", "server" ]'
+      target-repository: ShuttlePub/Emumet
+      target-ref: main
+
+  emumet-test-psql:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/test-psql.yml
+    with:
+      workspace: driver
+      target-repository: ShuttlePub/Emumet
+      target-ref: main

--- a/.github/workflows/test-psql.yml
+++ b/.github/workflows/test-psql.yml
@@ -6,13 +6,26 @@ on:
       workspace:
         type: string
         required: true
+      target-repository:
+        description: "Repository to checkout for running checks (default: caller repository)"
+        type: string
+        required: false
+        default: ""
+      target-ref:
+        description: "Ref of target-repository to checkout (default: caller ref)"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
   read-toolchain:
-    uses: ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main
+    uses: ./.github/workflows/read-toolchain.yml
+    with:
+      target-repository: ${{ inputs.target-repository }}
+      target-ref: ${{ inputs.target-ref }}
 
   check-psql:
     needs: [read-toolchain]
@@ -25,7 +38,6 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - "5432:5432"
-        # Set health checks to wait until postgres has started
         options: --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
@@ -37,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ inputs.target-repository }}
+          ref: ${{ inputs.target-ref }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
@@ -47,11 +61,8 @@ jobs:
           shared-key: ${{ inputs.workspace }}
       - name: Format check
         run: cargo fmt --verbose -p $WORKSPACE -- --check
-      - uses: giraffate/clippy-action@13b9d32482f25d29ead141b79e7e04e7900281e0 # v1.0.1
-        with:
-          reporter: 'github-pr-review'
-          clippy_flags: '-p ${{ inputs.workspace }} -- -Dwarnings'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clippy
+        run: cargo clippy --verbose -p "$WORKSPACE" --all-targets -- -D warnings
       - name: Build
         run: cargo build --verbose -p $WORKSPACE
       - name: Test

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ outputs
 
 ## Consumer integration tests
 
-[`test-consumers.yml`](.github/workflows/test-consumers.yml) runs on push/PR to `main` that touches `.github/workflows/**`. It invokes `check.yml` and `test-psql.yml` (at the same revision as the caller workflow — for `pull_request` events, that is the PR's merge commit) against real downstream repositories (Stellar, Emumet) using `target-repository` / `target-ref` inputs, so breaking changes are caught before merging.
+[`test-consumers.yml`](.github/workflows/test-consumers.yml) runs on push/PR to `main` that touches `.github/workflows/**`. It invokes `check.yml` and `test-psql.yml` (at the same revision as the caller workflow — for `pull_request` events, that is the PR's merge commit) against a real downstream repository (Emumet) using `target-repository` / `target-ref` inputs, so breaking changes are caught before merging.
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Runs lint and test
 `ShuttlePub/workflows/.github/workflows/check.yml@main`
 
 Inputs
-| name      | example                  |
-| --------  | ------------------------ |
-| workspace | '[ "kernel", "driver" ]' |
+| name              | required | example                  | description                                              |
+| ----------------- | -------- | ------------------------ | -------------------------------------------------------- |
+| workspace         | yes      | '[ "kernel", "driver" ]' | Workspaces to run check on                               |
+| target-repository | no       | ShuttlePub/Stellar       | Repository to checkout (default: caller repository)      |
+| target-ref        | no       | main                     | Ref of target-repository (default: caller ref)           |
 
 ### [test-psql.yml](.github/workflows/test-psql.yml)
 
@@ -20,9 +22,11 @@ Runs lint and test with PostgreSQL
 `ShuttlePub/workflows/.github/workflows/test-psql.yml@main`
 
 Inputs
-| name      | example                  |
-| --------  | ------------------------ |
-| workspace | '[ "kernel", "driver" ]' |
+| name              | required | example  | description                                              |
+| ----------------- | -------- | -------- | -------------------------------------------------------- |
+| workspace         | yes      | driver   | Workspace to run check on                                |
+| target-repository | no       | ShuttlePub/Emumet | Repository to checkout (default: caller repository) |
+| target-ref        | no       | main     | Ref of target-repository (default: caller ref)           |
 
 ### [coverage.yml](.github/workflows/coverage.yml)
 
@@ -93,6 +97,12 @@ Detect workspaces and outputs with matrix compatible format
 
 `ShuttlePub/workflows/.github/workflows/detect-workspaces.yml@main`
 
+Inputs
+| name              | required | example            | description                                              |
+| ----------------- | -------- | ------------------ | -------------------------------------------------------- |
+| target-repository | no       | ShuttlePub/Stellar | Repository to checkout (default: caller repository)      |
+| target-ref        | no       | main               | Ref of target-repository (default: caller ref)           |
+
 outputs
 
 | name   | example              |
@@ -107,9 +117,25 @@ Read toolchain channel from rust-toolchain.toml
 
 `ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main`
 
+Inputs
+| name              | required | example            | description                                              |
+| ----------------- | -------- | ------------------ | -------------------------------------------------------- |
+| target-repository | no       | ShuttlePub/Stellar | Repository to checkout (default: caller repository)      |
+| target-ref        | no       | main               | Ref of target-repository (default: caller ref)           |
+
 outputs
 
 | name    | example |
 | ------- | ------- |
 | channel | stable  |
+
+## Consumer integration tests
+
+[`test-consumers.yml`](.github/workflows/test-consumers.yml) runs on push/PR to `main` that touches `.github/workflows/**`. It invokes `check.yml` and `test-psql.yml` (at the same revision as the caller workflow — for `pull_request` events, that is the PR's merge commit) against real downstream repositories (Stellar, Emumet) using `target-repository` / `target-ref` inputs, so breaking changes are caught before merging.
+
+Notes:
+
+- **Fork PRs are skipped.** Consumer jobs only run for pushes to `main` and PRs from branches within the same repository (`github.event.pull_request.head.repo.full_name == github.repository`). This is intentional: cross-repo checkout of an external fork's modified workflow files would let untrusted code run with this repository's token. Maintainers can validate fork PRs by pushing the branch to this repository.
+- **Consumer repositories must be public.** Cross-repo `actions/checkout` uses the default `GITHUB_TOKEN`, which is scoped to this repository. Private/internal downstream repositories would require a PAT or GitHub App token, which is not configured.
+- **No repository token is exposed to cargo steps.** All checkouts use `persist-credentials: false`, and `cargo build/test/clippy` steps do not receive any `GITHUB_TOKEN` in their environment, so downstream Rust code has no access to this repository's token.
 


### PR DESCRIPTION
## Summary

- Validates breaking changes against real downstream repositories (Stellar, Emumet) **before** merging by exercising `check.yml` and `test-psql.yml` at the caller workflow's revision (for `pull_request`, the PR merge commit).
- Adds optional `target-repository` / `target-ref` inputs to `check.yml`, `test-psql.yml`, `detect-workspaces.yml`, `read-toolchain.yml` so they can checkout a consumer repo instead of this repo.
- Localizes internal `uses:` references (read-toolchain, detect-workspaces) so the PR-side workflow definition is exercised end-to-end (no `@main` indirection).
- Replaces `giraffate/clippy-action` with direct `cargo clippy --all-targets -- -D warnings` so non-zero exit reliably fails the job (clippy-action used `ignoreReturnCode: true`; its `github-pr-review` reporter was mismatched for cross-repo consumer CI).
- New `test-consumers.yml` runs on push/PR to `main` touching `.github/workflows/**`, with fork PRs skipped to avoid leaking the token to untrusted modified workflow files.

## Validation

- `actionlint` clean (only pre-existing SC2086 info findings).
- `zizmor --persona=auditor`: identical finding counts to pre-PR baseline (no new issues introduced).
- Two oracle review cycles passed with **no CRITICAL / no IMPORTANT** findings.

## Notes

- Consumer repos must be public (cross-repo `actions/checkout` uses the default `GITHUB_TOKEN` scoped to this repo).
- `persist-credentials: false` on all checkouts + no token in cargo env → no repository token is exposed to cargo steps.
- Fork PRs are intentionally skipped; maintainers can validate fork PRs by pushing the branch to this repo.

## Affected consumers in matrix

- `ShuttlePub/Stellar` (workspaces auto-detected via `detect-workspaces.yml`)
- `ShuttlePub/Emumet` (`check.yml` for `[kernel, adapter, application, server]`, `test-psql.yml` for `driver`)