### PR TITLE
:wrench: - Use self-repository syntax for internal workflow references

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,9 +14,9 @@ permissions:
   contents: read
 jobs:
   read-toolchain:
-    uses: ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main
+    uses: $/.github/workflows/read-toolchain.yml
   detect-workspaces:
-    uses: ShuttlePub/workflows/.github/workflows/detect-workspaces.yml@main
+    uses: $/.github/workflows/detect-workspaces.yml
   check:
     name: Bench ${{ matrix.workspace }}
     needs: [read-toolchain, detect-workspaces]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 jobs:
   read-toolchain:
-    uses: ./.github/workflows/read-toolchain.yml
+    uses: $/.github/workflows/read-toolchain.yml
     with:
       target-repository: ${{ inputs.target-repository }}
       target-ref: ${{ inputs.target-ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   read-toolchain:
-    uses: ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main
+    uses: $/.github/workflows/read-toolchain.yml
   coverage:
     name: Calculate coverage
     needs: read-toolchain

--- a/.github/workflows/test-consumers.yml
+++ b/.github/workflows/test-consumers.yml
@@ -18,14 +18,14 @@ permissions:
 jobs:
   emumet-check:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-    uses: ./.github/workflows/check.yml
+    uses: $/.github/workflows/check.yml
     with:
       workspace: '[ "kernel", "adapter", "application", "server" ]'
       target-repository: ShuttlePub/Emumet
       target-ref: main
   emumet-test-psql:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-    uses: ./.github/workflows/test-psql.yml
+    uses: $/.github/workflows/test-psql.yml
     with:
       workspace: driver
       target-repository: ShuttlePub/Emumet

--- a/.github/workflows/test-psql.yml
+++ b/.github/workflows/test-psql.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 jobs:
   read-toolchain:
-    uses: ./.github/workflows/read-toolchain.yml
+    uses: $/.github/workflows/read-toolchain.yml
     with:
       target-repository: ${{ inputs.target-repository }}
       target-ref: ${{ inputs.target-ref }}


### PR DESCRIPTION
## Summary

Replace internal reusable-workflow references with the new self-repository syntax (`$/`) announced in the [2026-07-30 changelog](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/).

A `uses:` value starting with `$/` resolves to this repository at the exact commit that is running — no checkout required, and no `@main` pin that Renovate keeps trying to update.

## Why

Some workflows referenced siblings as `ShuttlePub/workflows/.github/workflows/<wf>.yml@main`. Renovate's `github-actions` manager treats these as external dependencies and re-pins `@main` to the latest commit SHA on every run, producing an unbounded stream of patch PRs.

The `$/` form is not recognized as a remote dependency, so Renovate stops emitting PRs for these references. It also satisfies SHA-pinning policies without needing a hardcoded ref.

## Changes

| File | Before | After |
|------|--------|-------|
| `check.yml` | `./.github/workflows/read-toolchain.yml` | `$/.github/workflows/read-toolchain.yml` |
| `test-psql.yml` | `./.github/workflows/read-toolchain.yml` | `$/.github/workflows/read-toolchain.yml` |
| `test-consumers.yml` | `./.github/workflows/check.yml`, `./.github/workflows/test-psql.yml` | `$/...` |
| `coverage.yml` | `ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main` | `$/.github/workflows/read-toolchain.yml` |
| `bench.yml` | `ShuttlePub/workflows/.github/workflows/{read-toolchain,detect-workspaces}.yml@main` | `$/...` |

Consumer repositories (Emumet, Stellar, …) still call these workflows via `ShuttlePub/workflows/.github/workflows/<wf>.yml@main` — that cross-repo form is unchanged.

## Verification

- `Lint workflows` (actionlint + zizmor) must pass.
- `test-consumers` exercises `check.yml` → `read-toolchain.yml` and `test-psql.yml` → `read-toolchain.yml` via `$/` at the PR merge commit, proving runtime resolution end-to-end.
- `coverage.yml` and `bench.yml` are `workflow_call`-only; their `$/` resolution uses the identical mechanism exercised by `check.yml` above. They will be fully exercised on the next consumer CI run that invokes them.

## Runner requirement

Self-repository syntax requires runner ≥ 2.336.0. `ubuntu-latest` currently ships 2.336.0+ (confirmed in recent run logs).