### PR TITLE
:wrench: - Use workspace-relative path for internal workflow references

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,9 +14,9 @@ permissions:
   contents: read
 jobs:
   read-toolchain:
-    uses: ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main
+    uses: ./.github/workflows/read-toolchain.yml
   detect-workspaces:
-    uses: ShuttlePub/workflows/.github/workflows/detect-workspaces.yml@main
+    uses: ./.github/workflows/detect-workspaces.yml
   check:
     name: Bench ${{ matrix.workspace }}
     needs: [read-toolchain, detect-workspaces]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   read-toolchain:
-    uses: ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main
+    uses: ./.github/workflows/read-toolchain.yml
   coverage:
     name: Calculate coverage
     needs: read-toolchain


### PR DESCRIPTION
## Summary

Replace `ShuttlePub/workflows/.github/workflows/<wf>.yml@main` self-references in `coverage.yml` and `bench.yml` with the workspace-relative `./.github/workflows/<wf>.yml` form already used by `check.yml`, `test-psql.yml`, and `test-consumers.yml`.

## Why

Renovate's `github-actions` manager treats `owner/repo/path@ref` as an external dependency. These self-references caused Renovate to repeatedly open PRs re-pinning `@main` to the latest commit SHA — an unbounded stream of patch PRs for references that are always in the same repository.

The `./` form is not recognized as a remote dependency, so Renovate stops emitting PRs for them. It resolves to the same repository at the same ref, which is exactly the desired behavior.

## Why not `$/` (self-repository syntax)

The [2026-07-30 changelog](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) introduces `$/` as the recommended syntax. Runtime support is confirmed (all consumer tests passed in a trial PR), but **actionlint v1.7.12 does not recognize `$/`** (issue [rhysd/actionlint#711](https://github.com/rhysd/actionlint/issues/711) open, author inactive per [#719](https://github.com/rhysd/actionlint/issues/719)). The Lint workflows gate fails, blocking merge.

This PR uses `./` which actionlint already accepts. Migration to `$/` can happen once actionlint adds support.

## Changes

| File | Before | After |
|------|--------|-------|
| `coverage.yml:11` | `ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main` | `./.github/workflows/read-toolchain.yml` |
| `bench.yml:17` | `ShuttlePub/workflows/.github/workflows/read-toolchain.yml@main` | `./.github/workflows/read-toolchain.yml` |
| `bench.yml:19` | `ShuttlePub/workflows/.github/workflows/detect-workspaces.yml@main` | `./.github/workflows/detect-workspaces.yml` |

## Verification

- `Lint workflows` (actionlint + zizmor) must pass.
- `test-consumers` exercises `check.yml` and `test-psql.yml` (which already use `./`) — confirms the pattern works at runtime.
- `coverage.yml` and `bench.yml` are `workflow_call`-only; their `./` resolution uses the identical mechanism already proven by `check.yml`.